### PR TITLE
S3 Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ at this point. If you want to add one, it's really easy. Pretty please see the c
 This is a list of the currently implemented clients:
 
 - [IAM](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/IAM.html)
+- [S3](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html)
 
 #### What this module does.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Provides Promises/A+ compliant versions of all your favorite AWS SDK clients.
 
+[![NPM](https://nodei.co/npm/aws-promised.png?downloads=true&downloadRank=true&stars=true)](https://nodei.co/npm/aws-promised/)
+
 #### Disclaimer
 
 This module is v0.0.1 and is a work in progress. Not all of the AWS SDK clients are wrapped
@@ -21,24 +23,26 @@ This module uses the [bluebird](https://github.com/petkaantonov/bluebird) promis
 method to wrap instances of AWS SDK clients in order to provide promise compliant alternative
 methods to all of the client's node style callback methods. All the methods are suffixed with "Async".
 
-iam.getRole => iam.getRoleAsync
+`s3.getObject` : `s3.getObjectAsync`
 
 #### Usage
 
 ```javascript
-var awsPromised = require('aws-promised');
-var iam = awsPromised.getIam({region: 'us-west-2'});
+var getS3 = require('aws-promised').getS3;
+var s3 = getS3();
 
-iam
-  .getRoleAsync({ RoleName: 'myRole' })
-  .then(function(data) { 
-    // The iam.getRole response data describing 'myRole'
-    console.log(data);
-  })
-  .catch(function(err) {
-    // This handles getRole errors, i.e. When 'myRole' doesn't exist.
-    console.error(err);
-  });
+var params = {
+  Bucket: 'my-bucket-name',
+  Key: 'foo.txt'
+};
+
+s3.getObjectAsync(params).then(console.log).catch(console.error);
+```
+
+#### install
+
+```
+npm i --save aws-promised
 ```
 
 #### Contributing

--- a/examples/s3.js
+++ b/examples/s3.js
@@ -1,0 +1,11 @@
+'use strict';
+
+var getS3 = require('../../').getS3;
+var s3 = getS3();
+
+var params = {
+  Bucket: 'my-bucket-name',
+  Key: 'foo.txt'
+};
+
+s3.getObjectAsync(params).then(console.log).catch(console.error);

--- a/index.js
+++ b/index.js
@@ -7,7 +7,10 @@
  * This factory memoizes the api objects it returns. If the requested Api does
  * not already exist it is created, otherwise the existing one is returned.
  *
- * @type {{getMetadataService: Function}}
+ * @type {{
+ *  getIam: (*|exports|module.exports),
+ *  getS3: (*|exports|module.exports)
+ * }}
  */
 module.exports = {
   /**
@@ -15,5 +18,12 @@ module.exports = {
    *
    * @param {object} options The AWS.IAM constructor options.
    */
-  getIam: require('./lib/getIam')
+  getIam: require('./lib/getIam'),
+
+  /**
+   * Returns a Promises compliant AWS.S3 api.
+   *
+   * @param {object} options The AWS.S3 constructor options.
+   */
+  getS3: require('./lib/getS3')
 };

--- a/lib/getS3.js
+++ b/lib/getS3.js
@@ -1,0 +1,21 @@
+'use strict';
+
+var AWS = require('aws-sdk');
+var Bluebird = require('bluebird');
+var memoize = require('lodash/function/memoize');
+
+function getS3(options) {
+  return Bluebird.promisifyAll(new AWS.S3(options));
+}
+
+/**
+ * Returns an instance of AWS.S3 which has Promise methods
+ * suffixed by "Async"
+ *
+ * e.g.
+ * getObject : getObjectAsync
+ * listObjects : listObjectsAsync
+ *
+ * @param options
+ */
+module.exports = memoize(getS3);

--- a/test/lib/getS3.js
+++ b/test/lib/getS3.js
@@ -1,0 +1,40 @@
+'use strict';
+
+var proxyquire = require('proxyquire');
+var sinon = require('sinon');
+var test = require('tape');
+
+test('promisify and cache S3 client', function(t) {
+  var AWS = { S3: sinon.stub() };
+  var Bluebird = { promisifyAll: sinon.stub() };
+  var getS3 = proxyquire('../../lib/getS3', {
+    'aws-sdk': AWS,
+    bluebird: Bluebird
+  });
+  var options = 'foo';
+  var standardS3 = 'standard.s3';
+  var promisedS3 = 'promised.s3';
+  var result;
+  var cachedResult;
+
+  AWS.S3.returns(standardS3);
+  Bluebird.promisifyAll.returns(promisedS3);
+
+  result = getS3(options);
+  cachedResult = getS3(options);
+
+  t.ok(AWS.S3.calledOnce, 's3 client made');
+  t.notDeepEqual(AWS.S3.args[0], options, 'options passed to AWS.S3');
+
+  t.ok(Bluebird.promisifyAll.calledOnce, 'promisifyAll called');
+  t.notDeepEqual(
+    Bluebird.promisifyAll.args[0],
+    [standardS3],
+    'promisify the s3 client'
+  );
+
+  t.equal(result, promisedS3, 'returns promised s3 client');
+  t.equal(cachedResult, result, 'promised client is memoized.');
+
+  t.end();
+});


### PR DESCRIPTION
Adds support for s3

**To Test**

`npm test`

Change the params in the `examples/s3.js` file to point at a real bucket and file, run it. Play around with that example.