### PR TITLE
Promised suffix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: node_js
 node_js:
   - 0.10
   - 0.12
+  - iojs

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Basically,
 
 **Into**
 
-`s3.getObjectAsync` -- A Promises/A+ style API
+`s3.getObjectPromised` -- A Promises/A+ style API
 
 It decorates [aws-sdk](https://github.com/aws/aws-sdk-js) client instances with "Async" suffixed methods.
 Internally `aws-promised` uses
@@ -43,13 +43,13 @@ are still available for use when you need them.
 For instance, the "Async" promised methods return promises and not instances of
 [AWS.Request](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Request.html). So when you want to do something
 with AWS.Request (like open up a Node.js data stream from an s3 file) you're still able to use the original `getObject` 
-method to create the stream.
+method and `createReadStream`.
 
-```
-var s3 = require('aws-promised/getS3')();
-var params = { Bucket: 'foo', Key: 'bar.txt' };
-var fileStream = s3.getObject(param).createReadStream();
-```
+**Why "Promised" and not "Async" suffix?**
+
+Astute users of `bluebird` will notice that this module doesn't use the default suffix of `Async` for the promisified
+methods. This is because the `AWS.Lambda` client has one single method which already uses that suffix -- `.invokeAsync`. 
+`bluebird` throws an error when trying to promisify an API which contains methods with the promisified suffix.
 
 #### Usage
 
@@ -62,7 +62,7 @@ var params = {
   Key: 'foo.txt'
 };
 
-s3.getObjectAsync(params).then(console.log).catch(console.error);
+s3.getObjectPromised(params).then(console.log).catch(console.error);
 ```
 
 #### Node-style modules
@@ -73,6 +73,7 @@ In the above Usage example the `getS3` method can be required directly.
 
 ```
 var getS3 = require('aws-promised/getS3');
+var s3 = getS3({ region: 'us-west-2' });
 ```
 
 Or even...

--- a/examples/ec2.js
+++ b/examples/ec2.js
@@ -11,7 +11,7 @@ var params = {
 };
 
 ec2
-  .createSecurityGroupAsync(params)
+  .createSecurityGroupPromised(params)
   .then(addIngressRule)
   .then(success)
   .catch(console.error);
@@ -25,7 +25,7 @@ function addIngressRule(data) {
     ToPort: 8000
   };
 
-  return ec2.authorizeSecurityGroupIngressAsync(params);
+  return ec2.authorizeSecurityGroupIngressPromised(params);
 }
 
 function success() {

--- a/examples/s3.js
+++ b/examples/s3.js
@@ -8,4 +8,10 @@ var params = {
   Key: 'foo.txt'
 };
 
-s3.getObjectAsync(params).then(console.log).catch(console.error);
+s3.getObjectPromised(params)
+  .then(printContents)
+  .catch(console.error);
+
+function printContents(data) {
+  console.log(data.Body.toString());
+}

--- a/examples/sqs.js
+++ b/examples/sqs.js
@@ -1,15 +1,16 @@
 'use strict';
 
-var sqs = require('../getSQS')({ region: 'us-west-2' });
+var getSQS = require('../getSQS');
+var sqs = getSQS({ region: 'us-west-2' });
 
 sqs
-  .getQueueUrlAsync({ QueueName: 'my-queue' })
+  .getQueueUrlPromised({ QueueName: 'my-queue' })
   .then(receiveMessage)
   .then(logMessageBodies)
   .catch(console.error);
 
 function receiveMessage(data) {
-  return sqs.receiveMessageAsync({ QueueUrl: data.QueueUrl });
+  return sqs.receiveMessagePromised({ QueueUrl: data.QueueUrl });
 }
 
 function logMessageBodies(data) {

--- a/getEC2.js
+++ b/getEC2.js
@@ -1,11 +1,11 @@
 'use strict';
 
 var AWS = require('aws-sdk');
-var Bluebird = require('bluebird');
 var memoize = require('lodash/function/memoize');
+var promisifyAll = require('./lib/promisifyAll');
 
 function getEC2(options) {
-  return Bluebird.promisifyAll(new AWS.EC2(options));
+  return promisifyAll(new AWS.EC2(options));
 }
 
 /**

--- a/getEC2.js
+++ b/getEC2.js
@@ -10,10 +10,10 @@ function getEC2(options) {
 
 /**
  * Returns an instance of AWS.EC2 which has Promise methods
- * suffixed by "Async"
+ * suffixed by "Promised"
  *
  * e.g.
- * createImage => createImageAsync
+ * createImage => createImagePromised
  *
  * @param options
  */

--- a/getIAM.js
+++ b/getIAM.js
@@ -10,10 +10,10 @@ function getIAM(options) {
 
 /**
  * Returns an instance of AWS.IAM which has Promise methods
- * suffixed by "Async"
+ * suffixed by "Promised"
  *
  * e.g.
- * createRole => createRoleAsync
+ * createRole => createRolePromised
  *
  * @param options
  */

--- a/getIAM.js
+++ b/getIAM.js
@@ -1,11 +1,11 @@
 'use strict';
 
 var AWS = require('aws-sdk');
-var Bluebird = require('bluebird');
 var memoize = require('lodash/function/memoize');
+var promisifyAll = require('./lib/promisifyAll');
 
 function getIAM(options) {
-  return Bluebird.promisifyAll(new AWS.IAM(options));
+  return promisifyAll(new AWS.IAM(options));
 }
 
 /**

--- a/getS3.js
+++ b/getS3.js
@@ -1,20 +1,19 @@
 'use strict';
 
 var AWS = require('aws-sdk');
-var Bluebird = require('bluebird');
 var memoize = require('lodash/function/memoize');
+var promisifyAll = require('./lib/promisifyAll');
 
 function getS3(options) {
-  return Bluebird.promisifyAll(new AWS.S3(options));
+  return promisifyAll(new AWS.S3(options));
 }
 
 /**
  * Returns an instance of AWS.S3 which has Promise methods
- * suffixed by "Async"
+ * suffixed by "Promised"
  *
  * e.g.
- * getObject : getObjectAsync
- * listObjects : listObjectsAsync
+ * listObjects : listObjectsPromised
  *
  * @param options
  */

--- a/getSQS.js
+++ b/getSQS.js
@@ -1,19 +1,19 @@
 'use strict';
 
 var AWS = require('aws-sdk');
-var Bluebird = require('bluebird');
 var memoize = require('lodash/function/memoize');
+var promisifyAll = require('./lib/promisifyAll');
 
 function getSQS(options) {
-  return Bluebird.promisifyAll(new AWS.SQS(options));
+  return promisifyAll(new AWS.SQS(options));
 }
 
 /**
  * Returns an instance of AWS.SQS which has Promise methods
- * suffixed by "Async"
+ * suffixed by "Promised"
  *
  * e.g.
- * receiveMessage : receiveMessageAsync
+ * receiveMessage : receiveMessagePromised
  *
  * @param options
  */

--- a/lib/promisifyAll.js
+++ b/lib/promisifyAll.js
@@ -1,0 +1,10 @@
+'use strict';
+
+var Bluebird = require('bluebird');
+
+// Custom promisifier function which adds the "Promised" suffix.
+function promisifyAll(target) {
+  return Bluebird.promisifyAll(target, { suffix: "Promised" });
+}
+
+module.exports = promisifyAll;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Provides Promises/A+ compliant version of all your favorite AWS SDK clients.",
   "main": "index.js",
   "scripts": {
-    "test": "node_modules/.bin/tape test/**.js"
+    "test": "node_modules/.bin/tape test/*.js test/**/*.js"
   },
   "repository": {
     "type": "git",

--- a/test/getEC2.js
+++ b/test/getEC2.js
@@ -9,10 +9,10 @@ test('promisify and cache EC2 client', function(t) {
   var standardEC2 = { fake: 'ec2Instance' };
   var promisedEC2 = 'promised.ec2';
   var AWS = { EC2: sinon.stub().returns(standardEC2) };
-  var Bluebird = { promisifyAll: sinon.stub().returns(promisedEC2) };
+  var promisifyAll = sinon.stub().returns(promisedEC2);
   var getEC2 = proxyquire('../getEC2', {
     'aws-sdk': AWS,
-    bluebird: Bluebird
+    './lib/promisifyAll': promisifyAll
   });
   var result = getEC2(options);
   var cachedResult = getEC2(options);
@@ -21,10 +21,10 @@ test('promisify and cache EC2 client', function(t) {
   t.equal(AWS.EC2.args[0].length, 1);
   t.equal(AWS.EC2.args[0][0], options, 'options passed to AWS.EC2');
 
-  t.ok(Bluebird.promisifyAll.calledOnce, 'promisifyAll called');
-  t.equal(Bluebird.promisifyAll.args[0].length, 1);
+  t.ok(promisifyAll.calledOnce, 'promisifyAll called');
+  t.equal(promisifyAll.args[0].length, 1);
   t.equal(
-    Bluebird.promisifyAll.args[0][0],
+    promisifyAll.args[0][0],
     standardEC2,
     'promisify the ec2 client'
   );

--- a/test/getIAM.js
+++ b/test/getIAM.js
@@ -9,10 +9,10 @@ test('promisify and cache IAM client', function(t) {
   var standardIam = { fake: 'iamInstance' };
   var promisedIam = 'promised.iam';
   var AWS = { IAM: sinon.stub().returns(standardIam) };
-  var Bluebird = { promisifyAll: sinon.stub().returns(promisedIam) };
+  var promisifyAll = sinon.stub().returns(promisedIam);
   var getIAM = proxyquire('../getIAM', {
     'aws-sdk': AWS,
-    bluebird: Bluebird
+    './lib/promisifyAll': promisifyAll
   });
   var result = getIAM(options);
   var cachedResult = getIAM(options);
@@ -21,10 +21,10 @@ test('promisify and cache IAM client', function(t) {
   t.equal(AWS.IAM.args[0].length, 1);
   t.equal(AWS.IAM.args[0][0], options, 'options passed to AWS.IAM');
 
-  t.ok(Bluebird.promisifyAll.calledOnce, 'promisifyAll called');
-  t.equal(Bluebird.promisifyAll.args[0].length, 1);
+  t.ok(promisifyAll.calledOnce, 'promisifyAll called');
+  t.equal(promisifyAll.args[0].length, 1);
   t.equal(
-    Bluebird.promisifyAll.args[0][0],
+    promisifyAll.args[0][0],
     standardIam,
     'promisify the iam client'
   );

--- a/test/getS3.js
+++ b/test/getS3.js
@@ -9,10 +9,10 @@ test('promisify and cache S3 client', function(t) {
   var standardS3 = { fake: 's3Instance' };
   var promisedS3 = 'promised.s3';
   var AWS = { S3: sinon.stub().returns(standardS3) };
-  var Bluebird = { promisifyAll: sinon.stub().returns(promisedS3) };
+  var promisifyAll = sinon.stub().returns(promisedS3);
   var getS3 = proxyquire('../getS3', {
     'aws-sdk': AWS,
-    bluebird: Bluebird
+    './lib/promisifyAll': promisifyAll
   });
   var result = getS3(options);
   var cachedResult = getS3(options);
@@ -21,10 +21,10 @@ test('promisify and cache S3 client', function(t) {
   t.equal(AWS.S3.args[0].length, 1);
   t.equal(AWS.S3.args[0][0], options, 'options passed to AWS.S3');
 
-  t.ok(Bluebird.promisifyAll.calledOnce, 'promisifyAll called');
-  t.equal(Bluebird.promisifyAll.args[0].length, 1);
+  t.ok(promisifyAll.calledOnce, 'promisifyAll called');
+  t.equal(promisifyAll.args[0].length, 1);
   t.equal(
-    Bluebird.promisifyAll.args[0][0],
+    promisifyAll.args[0][0],
     standardS3,
     'promisify the s3 client'
   );

--- a/test/getSQS.js
+++ b/test/getSQS.js
@@ -9,10 +9,10 @@ test('promisify and cache sqs client', function(t) {
   var standardSQS = { fake: 'sqsInstance' };
   var promisedSQS = 'promised.sqs';
   var AWS = { SQS: sinon.stub().returns(standardSQS) };
-  var Bluebird = { promisifyAll: sinon.stub().returns(promisedSQS) };
+  var promisifyAll = sinon.stub().returns(promisedSQS);
   var getSQS = proxyquire('../getSQS', {
     'aws-sdk': AWS,
-    bluebird: Bluebird
+    './lib/promisifyAll': promisifyAll
   });
   var result = getSQS(options);
   var cachedResult = getSQS(options);
@@ -21,10 +21,10 @@ test('promisify and cache sqs client', function(t) {
   t.equal(AWS.SQS.args[0].length, 1);
   t.equal(AWS.SQS.args[0][0], options, 'options passed to AWS.SQS');
 
-  t.ok(Bluebird.promisifyAll.calledOnce, 'promisifyAll called');
-  t.equal(Bluebird.promisifyAll.args[0].length, 1);
+  t.ok(promisifyAll.calledOnce, 'promisifyAll called');
+  t.equal(promisifyAll.args[0].length, 1);
   t.equal(
-    Bluebird.promisifyAll.args[0][0],
+    promisifyAll.args[0][0],
     standardSQS,
     'promisify the SQS client'
   );

--- a/test/lib/promisifyAll.js
+++ b/test/lib/promisifyAll.js
@@ -1,0 +1,13 @@
+'use strict';
+
+var test = require('tape');
+
+test('calls promisifyAll on a target, with suffix option', function(t) {
+  var target = { myFunc: function() {} };
+  var promisifyAll = require('../../lib/promisifyAll');
+  var result = promisifyAll(target);
+
+  t.ok(typeof result.myFunc === 'function', 'myFunc still present');
+  t.ok(typeof result.myFuncPromised === 'function', 'myFuncPromised was made');
+  t.end();
+});


### PR DESCRIPTION
Moved all existing clients to use "Promised" suffix instead of "Async".

Introduced a module `./lib/promisifyAll` which centralizes the use of the custom suffix. All clients use this module instead of using `Bluebird.promisifyAll` directly.

Changed examples. Rewrote documentation.

This is a backwards compatibility breaking change. It will be released as a major version.
