### PR TITLE
Support for elastiCache promised

### DIFF
--- a/elastiCache.js
+++ b/elastiCache.js
@@ -1,0 +1,20 @@
+'use strict';
+
+var AWS = require('aws-sdk');
+var memoize = require('lodash/function/memoize');
+var promisifyAll = require('./lib/util/promisifyAll');
+
+function elastiCache(options) {
+  return promisifyAll(new AWS.ElastiCache(options));
+}
+
+/**
+ * Returns an instance of AWS.ElastiCache which has Promise methods
+ * suffixed by "Promised"
+ *
+ * e.g.
+ * addTagsToResource : addTagsToResourcePromised
+ *
+ * @param options
+ */
+module.exports = memoize(elastiCache);

--- a/examples/elastiCache.js
+++ b/examples/elastiCache.js
@@ -1,0 +1,23 @@
+'use strict';
+
+var awsPromised = require('../index');
+var elastiCache = awsPromised.elastiCache(
+  {
+    region: 'us-west-2',
+    Endpoint: 'endpoint:port'
+  }
+);
+
+var params = {
+  CacheClusterId: 'casc-dev-s2-sessions',
+  MaxRecords: 20,
+  ShowCacheNodeInfo: true
+};
+
+elastiCache.describeCacheClustersPromised(params)
+  .then(success)
+  .catch(console.error);
+
+function success(result) {
+  console.log(result);
+}

--- a/index.js
+++ b/index.js
@@ -57,6 +57,13 @@ module.exports = {
   ecs: require('./ecs'),
 
   /**
+   * Returns a Promise compliant AWS.ElastiCache api
+   *
+   * @param {object} options The AWS.ElastiCache constructor options.
+   */
+  elastiCache: require('./elastiCache'),
+
+  /**
    * Returns a Promises compliant AWS.ELB api.
    *
    * @param {object} options The AWS.ELB constructor options.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-promised",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Provides Promises/A+ compliant version of all your favorite AWS SDK clients.",
   "main": "lib/aws-promised.js",
   "scripts": {

--- a/test/elastiCache.js
+++ b/test/elastiCache.js
@@ -1,0 +1,41 @@
+'use strict';
+
+var proxyquire = require('proxyquire');
+var sinon = require('sinon');
+var test = require('tape');
+
+test('promisify and cache ElastiCache client', function(t) {
+  var options = 'foo';
+  var standardElastiCache = { fake: 'elastiCache' };
+  var promisedElastiCache = 'promised.elastiCache';
+  var AWS = { ElastiCache: sinon.stub().returns(standardElastiCache) };
+  var promisifyAll = sinon.stub().returns(promisedElastiCache);
+  var elastiCachePromised = proxyquire('../elastiCache', {
+    'aws-sdk': AWS,
+    './lib/util/promisifyAll': promisifyAll
+  });
+  var result = elastiCachePromised(options);
+  var cachedResult = elastiCachePromised(options);
+
+  t.ok(AWS.ElastiCache.calledOnce, 'elastiCache client made');
+  console.log(AWS.ElastiCache.args[0]);
+  t.equal(AWS.ElastiCache.args[0].length, 1);
+  t.equal(
+    AWS.ElastiCache.args[0][0],
+    options,
+    'options passed to AWS.ElastiCache'
+  );
+
+  t.ok(promisifyAll.calledOnce, 'promisifyAll called');
+  t.equal(promisifyAll.args[0].length, 1);
+  t.equal(
+    promisifyAll.args[0][0],
+    standardElastiCache,
+    'promisify the ElastiCache client'
+  );
+
+  t.equal(result, promisedElastiCache, 'returns promised ElastiCache client');
+  t.equal(cachedResult, result, 'promised client is memoized.');
+
+  t.end();
+});

--- a/test/index.js
+++ b/test/index.js
@@ -28,6 +28,11 @@ test('ecs is function', function(t) {
   t.equal(typeof clientFactory.ecs, 'function');
 });
 
+test('elastiCache is function', function(t) {
+  t.plan(1);
+  t.equal(typeof clientFactory.elastiCache, 'function');
+});
+
 test('elb is function', function(t) {
   t.plan(1);
   t.equal(typeof clientFactory.elb, 'function');


### PR DESCRIPTION
- Run unit tests
- To test example file - Create a t2 micro elastiCache 1 node cluster and substitute the endpoint in the example file.
- Running the example should return a description of the elastiCache cluster you just created.
